### PR TITLE
Added a total to transaction view

### DIFF
--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -32,7 +32,8 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
     QDateTime datetime = index.data(TransactionTableModel::DateRole).toDateTime();
     QString address = index.data(TransactionTableModel::AddressRole).toString();
     QString label = index.data(TransactionTableModel::LabelRole).toString();
-    qint64 amount = llabs(index.data(TransactionTableModel::AmountRole).toLongLong());
+    qint64 amount = index.data(TransactionTableModel::AmountRole).toLongLong();
+    qint64 abs_amount = llabs(amount);
     int status = index.data(TransactionTableModel::StatusRole).toInt();
 
     if(!showInactive && (status == TransactionStatus::Conflicted || status == TransactionStatus::NotAccepted))
@@ -43,8 +44,10 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
         return false;
     if (!address.contains(addrPrefix, Qt::CaseInsensitive) && !label.contains(addrPrefix, Qt::CaseInsensitive))
         return false;
-    if(amount < minAmount)
+    if(abs_amount < minAmount)
         return false;
+
+    totalAmount += amount;
 
     return true;
 }
@@ -53,24 +56,28 @@ void TransactionFilterProxy::setDateRange(const QDateTime &from, const QDateTime
 {
     this->dateFrom = from;
     this->dateTo = to;
+    totalAmount = 0;
     invalidateFilter();
 }
 
 void TransactionFilterProxy::setAddressPrefix(const QString &addrPrefix)
 {
     this->addrPrefix = addrPrefix;
+    totalAmount = 0;
     invalidateFilter();
 }
 
 void TransactionFilterProxy::setTypeFilter(quint32 modes)
 {
     this->typeFilter = modes;
+    totalAmount = 0;
     invalidateFilter();
 }
 
 void TransactionFilterProxy::setMinAmount(qint64 minimum)
 {
     this->minAmount = minimum;
+    totalAmount = 0;
     invalidateFilter();
 }
 

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -3,6 +3,7 @@
 
 #include <QSortFilterProxyModel>
 #include <QDateTime>
+#include <inttypes.h>
 
 /** Filter the transaction list according to pre-specified rules. */
 class TransactionFilterProxy : public QSortFilterProxyModel
@@ -35,6 +36,9 @@ public:
     void setShowInactive(bool showInactive);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
+
+    int64_t getTotalAmount() const { return totalAmount; }
+
 protected:
     bool filterAcceptsRow(int source_row, const QModelIndex & source_parent) const;
 
@@ -45,6 +49,7 @@ private:
     quint32 typeFilter;
     qint64 minAmount;
     int limitRows;
+    mutable int64_t totalAmount;
     bool showInactive;
 
 signals:

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -188,6 +188,9 @@ void TransactionView::setModel(WalletModel *model)
                 TransactionTableModel::Note, 200);
         transactionView->horizontalHeader()->resizeSection(
                 TransactionTableModel::Amount, 100);
+
+        transactionProxyModel->setMinAmount(0);
+        updateTotalAmount();
     }
 }
 
@@ -196,7 +199,7 @@ void TransactionView::chooseDate(int idx)
     if(!transactionProxyModel)
         return;
     QDate current = QDate::currentDate();
-    dateRangeWidget->setVisible(false);
+    enableDateRangeWidget(false);
     switch(dateWidget->itemData(idx).toInt())
     {
     case All:
@@ -233,10 +236,12 @@ void TransactionView::chooseDate(int idx)
                 TransactionFilterProxy::MAX_DATE);
         break;
     case Range:
-        dateRangeWidget->setVisible(true);
+        enableDateRangeWidget(true);
         dateRangeChanged();
         break;
     }
+
+    updateTotalAmount();
 }
 
 void TransactionView::chooseType(int idx)
@@ -245,6 +250,7 @@ void TransactionView::chooseType(int idx)
         return;
     transactionProxyModel->setTypeFilter(
         typeWidget->itemData(idx).toInt());
+    updateTotalAmount();
 }
 
 void TransactionView::changedPrefix(const QString &prefix)
@@ -252,6 +258,7 @@ void TransactionView::changedPrefix(const QString &prefix)
     if(!transactionProxyModel)
         return;
     transactionProxyModel->setAddressPrefix(prefix);
+    updateTotalAmount();
 }
 
 void TransactionView::changedAmount(const QString &amount)
@@ -267,7 +274,15 @@ void TransactionView::changedAmount(const QString &amount)
     {
         transactionProxyModel->setMinAmount(0);
     }
+    updateTotalAmount();
 }
+
+void TransactionView::updateTotalAmount()
+{
+    QString str = BitcoinUnits::format(BitcoinUnits::BTC, transactionProxyModel->getTotalAmount());
+    totalAmountWidget->setText(str);
+}
+
 
 void TransactionView::exportClicked()
 {
@@ -385,6 +400,14 @@ void TransactionView::showDetails()
     }
 }
 
+void TransactionView::enableDateRangeWidget(bool enable)
+{
+    dateFrom->setVisible(enable);
+    dateTo->setVisible(enable);
+    to->setVisible(enable);
+    range->setVisible(enable);
+}
+
 QWidget *TransactionView::createDateRangeWidget()
 {
     dateRangeWidget = new QFrame();
@@ -393,7 +416,8 @@ QWidget *TransactionView::createDateRangeWidget()
     QHBoxLayout *layout = new QHBoxLayout(dateRangeWidget);
     layout->setContentsMargins(0,0,0,0);
     layout->addSpacing(23);
-    layout->addWidget(new QLabel(tr("Range:")));
+    range = new QLabel(tr("Range:"));
+    layout->addWidget(range);
 
     dateFrom = new QDateTimeEdit(this);
     dateFrom->setDisplayFormat("dd/MM/yy");
@@ -401,7 +425,8 @@ QWidget *TransactionView::createDateRangeWidget()
     dateFrom->setMinimumWidth(100);
     dateFrom->setDate(QDate::currentDate().addDays(-7));
     layout->addWidget(dateFrom);
-    layout->addWidget(new QLabel(tr("to")));
+    to = new QLabel(tr("to"));
+    layout->addWidget(to);
 
     dateTo = new QDateTimeEdit(this);
     dateTo->setDisplayFormat("dd/MM/yy");
@@ -411,8 +436,15 @@ QWidget *TransactionView::createDateRangeWidget()
     layout->addWidget(dateTo);
     layout->addStretch();
 
+    layout->addWidget(new QLabel(tr("Total:")));
+    totalAmountWidget = new QLabel(this);
+    totalAmountWidget->setText("0");
+    totalAmountWidget->setFixedWidth(120);
+    totalAmountWidget->setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard);
+    layout->addWidget(totalAmountWidget);
+
     // Hide by default
-    dateRangeWidget->setVisible(false);
+    enableDateRangeWidget(false);
 
     // Notify on change
     connect(dateFrom, SIGNAL(dateChanged(QDate)), this, SLOT(dateRangeChanged()));
@@ -428,6 +460,7 @@ void TransactionView::dateRangeChanged()
     transactionProxyModel->setDateRange(
             QDateTime(dateFrom->date()),
             QDateTime(dateTo->date()).addDays(1));
+    updateTotalAmount();
 }
 
 void TransactionView::focusTransaction(const QModelIndex &idx)

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -14,6 +14,7 @@ class QModelIndex;
 class QMenu;
 class QFrame;
 class QDateTimeEdit;
+class QLabel;
 QT_END_NAMESPACE
 
 /** Widget showing the transaction list for a wallet, including a filter row.
@@ -48,14 +49,22 @@ private:
     QComboBox *typeWidget;
     QLineEdit *addressWidget;
     QLineEdit *amountWidget;
+    QLabel *totalAmountWidgetLabel;
+    QLabel *totalAmountWidget;
 
     QMenu *contextMenu;
 
     QFrame *dateRangeWidget;
     QDateTimeEdit *dateFrom;
     QDateTimeEdit *dateTo;
+    QLabel *to;
+    QLabel *range;
 
     QWidget *createDateRangeWidget();
+
+private:
+    void updateTotalAmount();
+    void enableDateRangeWidget(bool enable);
 
 private slots:
     void contextualMenu(const QPoint &);


### PR DESCRIPTION
Integrated code that totals selections made in the transaction view from presstab's hyperstake wallet. Added hiding of date label fields when not being used. Added ability to select total with keyboard or mouse.
